### PR TITLE
Swipe events

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -25,3 +25,4 @@ service-configuration
 maximdubrovin:uploadcare
 http
 check
+meteorhacks:subs-manager

--- a/.meteor/platforms
+++ b/.meteor/platforms
@@ -1,2 +1,3 @@
-server
+android
 browser
+server

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -49,6 +49,7 @@ meteor@1.1.11-beta.16
 meteor-base@1.0.1-beta.16
 meteor-env-dev@0.0.2-beta.16
 meteor-env-prod@0.0.2-beta.16
+meteorhacks:subs-manager@1.6.3
 minifier-css@1.1.8-beta.16
 minifier-js@1.1.8-beta.16
 minimongo@1.0.11-beta.16

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Pages which exist within an individual project.
 
 ## Publications
 
-`Meteor.subscribe('projects')` - Returns all the project docs to which the logged-in user has access.
+`Subs.subscribe('projects')` - Returns all the project docs to which the logged-in user has access.
 
-`Meteor.subscribe('project', PROJECT_ID)` - Returns the given project and all its pages, provided the logged in user has access to it.
+`Subs.subscribe('project', PROJECT_ID)` - Returns the given project and all its pages, provided the logged in user has access to it.
 
 ## Methods
 

--- a/client/components/edit/edit-color.jsx
+++ b/client/components/edit/edit-color.jsx
@@ -4,7 +4,8 @@ import ColorPicker from 'react-color'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.string,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   getInitialState: function () {
     return { color: this.props.content }
@@ -12,7 +13,7 @@ export default React.createClass({
   changeColor: function (colorData) {
     let newColor = '#' + colorData.hex
     this.setState({color: newColor})
-    this.props.parentState(newColor)
+    this.props.update(newColor)
   },
   render () {
     return (

--- a/client/components/edit/edit-img.jsx
+++ b/client/components/edit/edit-img.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.string,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   getInitialState: function () {
     return {
@@ -14,7 +15,7 @@ export default React.createClass({
     this.update()
   },
   update: function () {
-    this.props.parentState(this.refs.img.src)
+    this.props.update(this.refs.img.src)
   },
   uploadcare: function (e) {
     e.preventDefault()

--- a/client/components/edit/edit-list.jsx
+++ b/client/components/edit/edit-list.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.array,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   getInitialState: function () {
     return { list: this.props.content, lastMoved: -1, lastDir: 0 }
@@ -12,7 +13,7 @@ export default React.createClass({
     this.update()
   },
   update: function () {
-    this.props.parentState(this.state.list)
+    this.props.update(this.state.list)
   },
   move: function (index, dir, e) {
     e.preventDefault()
@@ -90,6 +91,6 @@ export default React.createClass({
     )
   },
   componentDidUpdate () {
-    this._focusButton && this._focusButton.focus()
+    this._focusButton && this._focusButton.focus() && this._focusButton.select()
   }
 })

--- a/client/components/edit/edit-map.jsx
+++ b/client/components/edit/edit-map.jsx
@@ -4,7 +4,8 @@ import { Map, TileLayer, Marker } from 'react-leaflet'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.array,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   getInitialState: function () {
     return {
@@ -16,7 +17,7 @@ export default React.createClass({
     this.setState({position: [e.latlng.lat, e.latlng.lng]}, this.update)
   },
   update: function () {
-    this.props.parentState(this.state.position)
+    this.props.update(this.state.position)
   },
   componentDidMount: function () {
     this.update()

--- a/client/components/edit/edit-text.jsx
+++ b/client/components/edit/edit-text.jsx
@@ -3,14 +3,17 @@ import React from 'react'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.string,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   update: function (e) {
-    this.props.parentState(this.refs.text.value)
+    this.props.update(this.refs.text.value)
   },
   render () {
     return (
-      <input type='text' className='form-control' ref='text' defaultValue={ this.props.content } onChange={ this.update }/>
+      <form onSubmit={this.props.save}>
+        <input type='text' className='form-control' ref='text' defaultValue={ this.props.content } onChange={ this.update }/>
+      </form>
     )
   }
 })

--- a/client/components/edit/edit-textarea.jsx
+++ b/client/components/edit/edit-textarea.jsx
@@ -3,14 +3,17 @@ import React from 'react'
 export default React.createClass({
   propTypes: {
     content: React.PropTypes.string,
-    parentState: React.PropTypes.func
+    update: React.PropTypes.func,
+    save: React.PropTypes.func
   },
   update: function (e) {
-    this.props.parentState(this.refs.textarea.value)
+    this.props.update(this.refs.textarea.value)
   },
   render () {
     return (
-      <textarea ref='textarea' className='form-control' rows='8' defaultValue={ this.props.content } onChange={ this.update }/>
+      <form onSubmit={ this.props.save }>
+        <textarea ref='textarea' className='form-control' rows='8' defaultValue={ this.props.content } onChange={ this.update }/>
+      </form>
     )
   }
 })

--- a/client/components/edit/index.js
+++ b/client/components/edit/index.js
@@ -1,0 +1,15 @@
+import color from './edit-color'
+import img from './edit-img'
+import list from './edit-list'
+import map from './edit-map'
+import text from './edit-text'
+import textarea from './edit-textarea'
+
+export {
+  color,
+  img,
+  list,
+  map,
+  text,
+  textarea
+}

--- a/client/components/field-lookup.jsx
+++ b/client/components/field-lookup.jsx
@@ -1,20 +1,8 @@
 import React from 'react'
-import TextField from './edit/edit-text'
-import Textarea from './edit/edit-textarea'
-import UnorderedList from './edit/edit-list'
-import SingleImage from './edit/edit-img'
-import Map from './edit/edit-map'
-import ColorPicker from './edit/edit-color'
+import * as Components from './edit'
 
-const components = {
-  text: (content, parentState) => (<TextField content={ content } parentState={ parentState }/>),
-  textarea: (content, parentState) => (<Textarea content={ content } parentState={ parentState }/>),
-  list: (content, parentState) => (<UnorderedList content={ content } parentState={ parentState }/>),
-  img: (content, parentState) => (<SingleImage content={ content } parentState={ parentState }/>),
-  map: (content, parentState) => (<Map content={ content } parentState={ parentState }/>),
-  color: (content, parentState) => (<ColorPicker content={ content } parentState={ parentState }/>)
-}
-
-module.exports = function (type, content, parentState) {
-  return components[type](content, parentState)
+module.exports = function (type, content, update, save) {
+  let Component = Components[`${type}`]
+  let props = { content, update, save }
+  return (<Component {...props} />)
 }

--- a/client/components/loader.jsx
+++ b/client/components/loader.jsx
@@ -27,6 +27,6 @@ const options = {
 
 export default React.createClass({
   render() {
-    return <ReactLoader {...this.props} options={options} />
+    return <ReactLoader options={options} {...this.props} />
   }
 })

--- a/client/components/login-with-github.jsx
+++ b/client/components/login-with-github.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Loader from './loader'
+import OverlayLoader from './overlay-loader'
 
 export const LoginWithGithub = React.createClass({
   mixins: [ReactMeteorData],
@@ -7,12 +7,15 @@ export const LoginWithGithub = React.createClass({
   getMeteorData () {
     var user = Meteor.user()
     return {
-      user: Meteor.user(),
-      loggingIn: Meteor.loggingIn()
+      user: Meteor.user()
     }
   },
+  getInitialState () {
+    return { loginSpinner: false }
+  },
   login () {
-    Meteor.loginWithGithub({ requestPermissions: ['repo'] })
+    this.setState({ loginSpinner: true })
+    Meteor.loginWithGithub({ requestPermissions: ['repo'] }, this.setState.bind(this, { loginSpinner: false }))
   },
   logout () {
     Meteor.logout()
@@ -25,8 +28,8 @@ export const LoginWithGithub = React.createClass({
           <button className="btn btn-primary-outline" type="button" onClick={this.logout}>Log out</button>
         </div>
       )
-    } else if (this.data.loggingIn) {
-      return (<Loader loaded={false}/>)
+    } else if (this.state.loginSpinner) {
+      return (<OverlayLoader color='#ddd' position='relative' />)
     } else {
       return (
         <div>

--- a/client/components/overlay-loader.jsx
+++ b/client/components/overlay-loader.jsx
@@ -1,20 +1,21 @@
 import React from 'react'
 import Loader from './loader'
 
+let style = {
+  position: 'fixed',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.2)'
+}
+
 export default React.createClass({
   render () {
     if (this.props.loaded) return false
-    let style = {
-      position: 'fixed',
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.2)'
-    }
     return (
       <div style={style}>
-        <Loader />
+        <Loader options={{ position: 'relative', color: '#ddd' }} />
       </div>
     )
   }

--- a/client/components/page-count.jsx
+++ b/client/components/page-count.jsx
@@ -1,0 +1,6 @@
+var count = 0
+
+export default {
+  get () { return count },
+  inc () { count += 1 }
+}

--- a/client/components/page-transition.jsx
+++ b/client/components/page-transition.jsx
@@ -1,18 +1,50 @@
 import React from 'react'
 import Swipeable from 'react-swipeable'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import pageCount from './page-count'
 
-let counter = 0
+let swipeDistance = Math.min(window.innerWidth / 3, 120)
+let transitionLengthNormal = 100
+let transitionLengthLong = 250
 
 export default React.createClass({
+  getInitialState () {
+    return { offset: 0, transitionLength: transitionLengthNormal }
+  },
+  swipe (evt, xOffset, yOffset) {
+    if (Math.abs(xOffset) < 30 || Math.abs(yOffset) > 50) return
+    evt.preventDefault()
+    this.setState({ offset: Math.max(Math.min(xOffset, swipeDistance), -swipeDistance), transition: false })
+  },
+  swipeEnd () {
+    var transitionLength = transitionLengthNormal
+    if (this.state.offset < -(swipeDistance * 0.9)) {
+      transitionLength = transitionLengthLong
+      this.setState({ transitionLength: transitionLengthLong }, this.props.pageBack)
+    }
+    this.setState({ transition: true }, () => setTimeout(() => {
+      this.setState({ offset: 0 }, () => {
+        setTimeout(() => {
+          this.setState({ transition: false, transitionLength: transitionLengthNormal })
+        }, transitionLength)
+      })
+    }, 50))
+  },
   render () {
-    counter += 1
     return (
       <div>
-        <Swipeable onSwipedRight={(this.props && this.props.pageBack) || (() => {})}>
-          <ReactCSSTransitionGroup transitionName={`slide-${this.props.dir}`} transitionEnterTimeout={250} transitionLeaveTimeout={250}>
-            <div key={counter} style={{position: 'absolute', display: 'inline-block', width: '100%'}}>{this.props.children}</div>
-          </ReactCSSTransitionGroup>
+        <Swipeable onSwiping={this.swipe} onSwiped={this.swipeEnd}>
+          <div style={{
+              position: 'relative',
+              right: `${this.state.offset}px`,
+              transition: this.state.transition ? `right ${this.state.transitionLength}ms ease-out` : null,
+              WebkitTransition: this.state.transition ? `right ${this.state.transitionLength}ms ease-out` : null,
+              msTransition: this.state.transition ? `right ${this.state.transitionLength}ms ease-out` : null,
+          }}>
+            <ReactCSSTransitionGroup transitionName={`slide-${this.props.dir}`} transitionEnterTimeout={250} transitionLeaveTimeout={250}>
+              <div key={pageCount.get()} style={{position: 'absolute', display: 'inline-block', width: '100%'}}>{this.props.children}</div>
+            </ReactCSSTransitionGroup>
+          </div>
         </Swipeable>
       </div>
     )

--- a/client/components/page-transitions.scss
+++ b/client/components/page-transitions.scss
@@ -1,35 +1,35 @@
 .slide-left-enter {
   left: 100%;
+  transition: left 250ms ease-in-out;
 
   &.slide-left-enter-active {
     left: 0;
-    transition: left 250ms ease-in-out;
   }
 }
 
 .slide-left-leave {
   left: 0;
+  transition: left 250ms ease-in-out;
 
   &.slide-left-leave-active {
     left: -100%;
-    transition: left 250ms ease-in-out;
   }
 }
 
 .slide-right-enter {
   left: -100%;
+  transition: left 250ms ease-in-out;
 
   &.slide-right-enter-active {
     left: 0;
-    transition: left 250ms ease-in-out;
   }
 }
 
 .slide-right-leave {
   left: 0;
+  transition: left 250ms ease-in-out;
 
   &.slide-right-leave-active {
     left: 100%;
-    transition: left 250ms ease-in-out;
   }
 }

--- a/client/components/universal-loader.jsx
+++ b/client/components/universal-loader.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Loader from './loader'
+
+var loaderShown = false
+var instanceUpdaters = []
+var index = 1
+
+export const UniversalLoader = React.createClass({
+  componentWillMount () {
+    instanceUpdaters.push(this.forceUpdate.bind(this))
+  },
+  componentWillUnmount () {
+    instanceUpdaters = instanceUpdaters.filter(updater => updater !== this.forceUpdate)
+  },
+  getInitialState () {
+    return { show: false }
+  },
+  render () {
+    return loaderShown ? (<Loader options={{position: 'relative'}} {...this.props} />) : null
+  }
+})
+
+export const showLoader = function(state) {
+  loaderShown = state
+  instanceUpdaters.forEach(updater => updater())
+}

--- a/client/components/universal-loader.jsx
+++ b/client/components/universal-loader.jsx
@@ -20,7 +20,7 @@ export const UniversalLoader = React.createClass({
   }
 })
 
-export const showLoader = function(state) {
+export const showLoader = function (state) {
   loaderShown = state
   instanceUpdaters.forEach(updater => updater())
 }

--- a/client/main.scss
+++ b/client/main.scss
@@ -48,16 +48,17 @@ html, body, #react-root {
   flex-direction: column;
 
   .content {
-    display: flex;
     position: relative;
     overflow-y: scroll;
     flex: 1 1;
     > * {
-      display: flex;
+      position: absolute;
       width: 100%;
+      height: 100%;
     }
     > * > * {
       width: 100%;
+      height: 100%;
     }
   }
   .navbar, .footer {

--- a/client/main.scss
+++ b/client/main.scss
@@ -48,9 +48,17 @@ html, body, #react-root {
   flex-direction: column;
 
   .content {
+    display: flex;
     position: relative;
     overflow-y: scroll;
     flex: 1 1;
+    > * {
+      display: flex;
+      width: 100%;
+    }
+    > * > * {
+      width: 100%;
+    }
   }
   .navbar, .footer {
     flex: none;

--- a/client/pages/facts-edit.jsx
+++ b/client/pages/facts-edit.jsx
@@ -20,6 +20,7 @@ export default React.createClass({
     }
   },
   render () {
+    if (!Subs.ready()) return false
     var props = {
       project: this.data.project,
       field: this.props.field
@@ -78,7 +79,7 @@ var ProjectField = React.createClass({
     })
   },
   render () {
-    let fieldComponent = fields(this.state.type, this.state.content, this.update)
+    let fieldComponent = fields(this.state.type, this.state.content, this.update, this.save)
     return (
       <div>
         <Breadcrumbs pages={[

--- a/client/pages/facts-edit.jsx
+++ b/client/pages/facts-edit.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Loader from '../components/loader'
 import OverlayLoader from '../components/overlay-loader'
 import Breadcrumbs from '../components/breadcrumbs'
 import ValidationError from '../components/validation-error'
@@ -13,7 +12,7 @@ export default React.createClass({
     field: React.PropTypes.string || null
   },
   getMeteorData () {
-    var projectSub = Meteor.subscribe('project', this.props.projectId)
+    var projectSub = Subs.subscribe('project', this.props.projectId)
     let project = Projects.findOne({ _id: this.props.projectId })
     return {
       projectReady: projectSub.ready(),
@@ -21,7 +20,6 @@ export default React.createClass({
     }
   },
   render () {
-    if (!this.data.projectReady) return (<Loader loaded={false} />)
     var props = {
       project: this.data.project,
       field: this.props.field

--- a/client/pages/facts.jsx
+++ b/client/pages/facts.jsx
@@ -11,10 +11,12 @@ export default React.createClass({
   getMeteorData () {
     var projectSub = Subs.subscribe('project', this.props.projectId)
     return {
-      project: Projects.findOne({ _id: this.props.projectId })
+      project: Projects.findOne({ _id: this.props.projectId }),
+      subsReady: Subs.ready()
     }
   },
   render () {
+    if (!this.data.subsReady) return false
     let facts = Object.keys(this.data.project.facts.json)
     return (
       <div>

--- a/client/pages/facts.jsx
+++ b/client/pages/facts.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Loader from '../components/loader'
 import Breadcrumbs from '../components/breadcrumbs'
 import FieldPreview from '../components/field-preview'
 
@@ -10,14 +9,12 @@ export default React.createClass({
   },
   mixins: [ReactMeteorData],
   getMeteorData () {
-    var projectSub = Meteor.subscribe('project', this.props.projectId)
+    var projectSub = Subs.subscribe('project', this.props.projectId)
     return {
-      projectReady: projectSub.ready(),
       project: Projects.findOne({ _id: this.props.projectId })
     }
   },
   render () {
-    if (!this.data.projectReady) return (<Loader loaded={false} />)
     let facts = Object.keys(this.data.project.facts.json)
     return (
       <div>

--- a/client/pages/home.jsx
+++ b/client/pages/home.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import moment from 'moment'
+import Loader from '../components/loader'
 import { LoginWithGithub } from '../components/login-with-github'
 import { ProjectCard } from '../components/project-card'
 
@@ -23,6 +24,8 @@ export default React.createClass({
           <LoginWithGithub />
         </div>
       )
+    } else if (this.data.loggingIn) {
+      return <Loader loaded={false} color='#ddd' />
     }
     return (
       <div className="container-fluid">

--- a/client/pages/home.jsx
+++ b/client/pages/home.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import moment from 'moment'
-import Loader from '../components/loader'
 import { LoginWithGithub } from '../components/login-with-github'
 import { ProjectCard } from '../components/project-card'
 
@@ -8,11 +7,10 @@ export default React.createClass({
   mixins: [ReactMeteorData],
 
   getMeteorData () {
-    var projectSub = Meteor.subscribe('projects')
+    var projectSub = Subs.subscribe('projects')
     return {
       user: Meteor.user(),
       loggingIn: Meteor.loggingIn(),
-      projectsReady: projectSub.ready(),
       projects: Projects.find({}).fetch()
     }
   },
@@ -29,7 +27,7 @@ export default React.createClass({
     return (
       <div className="container-fluid">
         <p className="lead m-t-1">Pick a site</p>
-        {this.data.projectsReady ? <ProjectsList projects={this.data.projects} /> : <Loader loaded={false} />}
+          <ProjectsList projects={this.data.projects} />
         <LoginWithGithub />
       </div>
     )

--- a/client/pages/layout.jsx
+++ b/client/pages/layout.jsx
@@ -4,7 +4,10 @@ import PageTransition from '../components/page-transition'
 import Footer from '../components/footer'
 
 let pageBack = function () {
-  window.history.back()
+  let current = FlowRouter.current()
+  let parent = current.route.options.parent
+  if (!parent) return
+  FlowRouter.go(parent, current.params, current.queryParams)
 }
 
 export default ({ content, dir }) => (

--- a/client/pages/layout.jsx
+++ b/client/pages/layout.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Navbar } from '../components/navbar'
 import PageTransition from '../components/page-transition'
 import Footer from '../components/footer'
+import { UniversalLoader } from '../components/universal-loader'
 
 let pageBack = function () {
   let current = FlowRouter.current()
@@ -17,6 +18,7 @@ export default ({ content, dir }) => (
       <PageTransition dir={dir} pageBack={pageBack}>
         {content}
       </PageTransition>
+      <UniversalLoader></UniversalLoader>
     </div>
     <Footer />
   </div>

--- a/client/pages/page-edit.jsx
+++ b/client/pages/page-edit.jsx
@@ -91,7 +91,7 @@ var PageField = React.createClass({
         <Breadcrumbs pages={[
           { text: 'Home', href: '/' },
           { text: 'Site', href: `/project/${this.props.project._id}` },
-          { text: this.props.page.name, href: `/page/${this.props.page._id}` }
+          { text: this.props.page.name, href: `/project/${this.props.project._id}/page/${this.props.page._id}` }
         ]} />
         <div className="container">
           <p>Edit <code>{this.props.field}</code></p>
@@ -101,7 +101,7 @@ var PageField = React.createClass({
           <ValidationError message={this.state.validationError} />
           <div className="m-b-1">
             <button onClick={ this.save } className='btn btn-primary'>Save</button>
-            <a href={`/page/${this.props.page._id}`} className="btn btn-link">Cancel</a>
+            <a href={`/project/${this.props.project._id}/page/${this.props.page._id}`} className="btn btn-link">Cancel</a>
           </div>
         </div>
         <OverlayLoader loaded={!this.state.saving} />

--- a/client/pages/page-edit.jsx
+++ b/client/pages/page-edit.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Loader from '../components/loader'
 import OverlayLoader from '../components/overlay-loader'
 import Breadcrumbs from '../components/breadcrumbs'
 import ValidationError from '../components/validation-error'
@@ -13,7 +12,7 @@ export default React.createClass({
     field: React.PropTypes.string
   },
   getMeteorData () {
-    var pageSub = Meteor.subscribe('page', this.props.pageId)
+    var pageSub = Subs.subscribe('page', this.props.pageId)
     let page = Pages.findOne({ _id: this.props.pageId })
     return {
       pageReady: pageSub.ready(),
@@ -22,7 +21,6 @@ export default React.createClass({
     }
   },
   render () {
-    if (!this.data.pageReady) return (<Loader loaded={false} />)
     var props = {
       page: this.data.page,
       project: this.data.project,

--- a/client/pages/page-edit.jsx
+++ b/client/pages/page-edit.jsx
@@ -17,10 +17,12 @@ export default React.createClass({
     return {
       pageReady: pageSub.ready(),
       page: page,
-      project: Projects.findOne({ _id: page && page.project._id })
+      project: Projects.findOne({ _id: page && page.project._id }),
+      subsReady: Subs.ready()
     }
   },
   render () {
+    if (!this.data.subsReady) return false
     var props = {
       page: this.data.page,
       project: this.data.project,
@@ -79,11 +81,11 @@ var PageField = React.createClass({
         this.setState({ validationError: 'Cannot update page data' })
         return console.error(err)
       }
-      FlowRouter.go('page', { pageId: this.props.page._id })
+      FlowRouter.go('page', { pageId: this.props.page._id, projectId: this.props.project._id })
     })
   },
   render () {
-    let field = fields(this.state.type, this.state.content, this.update)
+    let field = fields(this.state.type, this.state.content, this.update, this.save)
     return (
       <div>
         <Breadcrumbs pages={[

--- a/client/pages/page.jsx
+++ b/client/pages/page.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
               let type = schema && schema.type
               let value = this.data.page.content.json[field]
               return (
-                <a className='list-group-item' key={ind} href={`/page/${this.data.page._id}/edit?field=${field}`}>
+                <a className='list-group-item' key={ind} href={`/project/${this.data.project._id}/page/${this.data.page._id}/edit?field=${field}`}>
                   <p><code>{field}</code></p>
                   <div><em>
                     <FieldPreview type={type} value={value} />

--- a/client/pages/page.jsx
+++ b/client/pages/page.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Loader from '../components/loader'
 import Breadcrumbs from '../components/breadcrumbs'
 import FieldPreview from '../components/field-preview'
 
@@ -7,7 +6,7 @@ export default React.createClass({
   mixins: [ReactMeteorData],
 
   getMeteorData () {
-    var pageSub = Meteor.subscribe('page', this.props.pageId)
+    var pageSub = Subs.subscribe('page', this.props.pageId)
     let page = Pages.findOne({ _id: this.props.pageId })
     return {
       pageReady: pageSub.ready(),
@@ -17,7 +16,6 @@ export default React.createClass({
   },
 
   render () {
-    if (!this.data.pageReady) return (<Loader loaded={false} />)
     let content = Object.keys(this.data.page.content.json)
     return (
       <div>

--- a/client/pages/page.jsx
+++ b/client/pages/page.jsx
@@ -11,11 +11,13 @@ export default React.createClass({
     return {
       pageReady: pageSub.ready(),
       page: page,
-      project: Projects.findOne({ _id: page && page.project._id })
+      project: Projects.findOne({ _id: page && page.project._id }),
+      subsReady: Subs.ready()
     }
   },
 
   render () {
+    if (!this.data.subsReady) return false
     let content = Object.keys(this.data.page.content.json)
     return (
       <div>

--- a/client/pages/project.jsx
+++ b/client/pages/project.jsx
@@ -1,21 +1,18 @@
 import React from 'react'
-import Loader from '../components/loader'
 import Breadcrumbs from '../components/breadcrumbs'
 
 export default React.createClass({
   mixins: [ReactMeteorData],
 
   getMeteorData () {
-    var projectSub = Meteor.subscribe('project', this.props.projectId)
+    var projectSub = Subs.subscribe('project', this.props.projectId)
     return {
-      projectReady: projectSub.ready(),
       project: Projects.findOne({ _id: this.props.projectId }),
       pages: Pages.find({ 'project._id': this.props.projectId }).fetch()
     }
   },
 
   render () {
-    if (!this.data.projectReady) return (<Loader loaded={false} />)
     return (
       <div>
         <Breadcrumbs pages={[

--- a/client/pages/project.jsx
+++ b/client/pages/project.jsx
@@ -8,11 +8,13 @@ export default React.createClass({
     var projectSub = Subs.subscribe('project', this.props.projectId)
     return {
       project: Projects.findOne({ _id: this.props.projectId }),
-      pages: Pages.find({ 'project._id': this.props.projectId }).fetch()
+      pages: Pages.find({ 'project._id': this.props.projectId }).fetch(),
+      subsReady: Subs.ready()
     }
   },
 
   render () {
+    if (!this.data.subsReady) return false
     return (
       <div>
         <Breadcrumbs pages={[

--- a/client/pages/project.jsx
+++ b/client/pages/project.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
           <p className="lead m-t-1">Pick a page</p>
           <div className='list-group'>
             <a className='list-group-item' href={`/project/${this.props.projectId}/facts`}>Website settings</a>
-            {this.data.pages.map(page => (<a className='list-group-item' key={page._id} href={`/page/${page._id}`}>Page - {page.name}</a>))}
+            {this.data.pages.map(page => (<a className='list-group-item' key={page._id} href={`/project/${this.data.project._id}/page/${page._id}`}>Page - {page.name}</a>))}
           </div>
         </div>
       </div>

--- a/client/routes.js
+++ b/client/routes.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'react-mounter'
 import * as pages from './pages'
 import pageCount from './components/page-count'
+import './subs-manager'
 
 FlowRouter.triggers.enter([
   function (ctx) {

--- a/client/routes.js
+++ b/client/routes.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import { mount } from 'react-mounter'
 import * as pages from './pages'
+import pageCount from './components/page-count'
 
 FlowRouter.triggers.enter([
   function (ctx) {
+    pageCount.inc()
     ctx.params._dir = (ctx.oldRoute && ctx.oldRoute.options.index > ctx.route.options.index) ? 'right' : 'left'
   }
 ])
@@ -22,6 +24,7 @@ FlowRouter.route('/', {
 FlowRouter.route('/project/:projectId', {
   name: 'project',
   index: 1,
+  parent: 'home',
   action (params) {
     mount(pages.Layout, {
       content: React.createElement(pages.Project, {projectId: params.projectId}),
@@ -33,6 +36,7 @@ FlowRouter.route('/project/:projectId', {
 FlowRouter.route('/project/:projectId/facts', {
   name: 'project-facts',
   index: 2,
+  parent: 'project',
   action (params) {
     mount(pages.Layout, {
       content: React.createElement(pages.Facts, {projectId: params.projectId}),
@@ -44,6 +48,7 @@ FlowRouter.route('/project/:projectId/facts', {
 FlowRouter.route('/project/:projectId/facts/edit', {
   name: 'project-facts-edit',
   index: 3,
+  parent: 'project-facts',
   action (params, queryParams) {
     if (!queryParams || !queryParams.field) {
       FlowRouter.go('project-facts')
@@ -56,9 +61,10 @@ FlowRouter.route('/project/:projectId/facts/edit', {
   }
 })
 
-FlowRouter.route('/page/:pageId', {
-  index: 2,
+FlowRouter.route('/project/:projectId/page/:pageId', {
   name: 'page',
+  index: 2,
+  parent: 'project',
   action (params) {
     mount(pages.Layout, {
       content: React.createElement(pages.Page, {pageId: params.pageId}),
@@ -67,9 +73,10 @@ FlowRouter.route('/page/:pageId', {
   }
 })
 
-FlowRouter.route('/page/:pageId/edit', {
-  index: 3,
+FlowRouter.route('/project/:projectId/page/:pageId/edit', {
   name: 'page-edit',
+  index: 3,
+  parent: 'page',
   action (params, queryParams) {
     if (!queryParams || !queryParams.field) {
       FlowRouter.go('page')

--- a/client/subs-manager.js
+++ b/client/subs-manager.js
@@ -1,0 +1,11 @@
+import { showLoader } from './components/universal-loader'
+
+Subs = new SubsManager()
+
+Tracker.autorun(() => {
+  if (Subs.ready()) {
+    showLoader(false)
+  } else {
+    showLoader(true)
+  }
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "npm-run-all build:* --parallel watch:* meteor",
+    "start-android": "npm-run-all build:* --parallel watch:* meteor-android",
     "meteor": "meteor --settings settings.json",
+    "meteor-android": "meteor run android-device --settings settings.json",
     "build:css": "node-sass --output-style compact --include-path node_modules client/main.scss | postcss --local-plugins --use autoprefixer --output client/bundle.css",
     "watch:css": "nodemon -w client -e scss -x npm run build:css"
   },


### PR DESCRIPTION
* Adds a central subs manager using *meteorhacks:subs-manager* to cache subscriptions.
* This allows the use of a global *universal-loader* package to display a spinner whenever we are waiting on subs.
* Adds swipe interactions which move the page naturally and trigger a return to the parent page (as defined in the router) whenever we swipe back.
* Refactors *field-lookup* to simplify it and allow the user to pass a save method so that an interaction *within* the component (like hitting enter in an input box) can trigger a save.
* Adds and corrects loading spinners throughout the site.